### PR TITLE
Add proposal: Simplify joins with info metrics in PromQL

### DIFF
--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -150,5 +150,5 @@ Instead of encoding metadata, e.g. OTel resource attributes, as info metric labe
 
 The tasks to do in order to migrate to the new idea.
 
-* [ ] Task one <GH issue>
-* [ ] Task two <GH issue> ...
+* [ ] [Add experimental PromQL `info` function MVP](https://github.com/prometheus/prometheus/pull/14495)
+* [ ] Extend `info` function MVP with the ability to support `info` metrics in general, with persistence of info metrics metadata

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -1,0 +1,78 @@
+## Native Support for Info Metrics Metadata
+
+* **Owners:**
+  * Arve Knudsen [@aknuds1](https://github.com/aknuds1) [arve.knudsen@grafana.com](mailto:arve.knudsen@grafana.com)
+
+* **Implementation Status:** Partially implemented
+
+* **Related Issues and PRs:**
+  * [WIP: Info PromQL function prototype](https://github.com/grafana/mimir-prometheus/pull/598)
+
+* **Other docs or links:**
+  * [Proper support for OTEL resource attributes](https://docs.google.com/document/d/1FgHxOzCQ1Rom-PjHXsgujK8x5Xx3GTiwyG__U3Gd9Tw/edit#heading=h.unv3m5m27vuc)
+  * [Special treatment of info metrics in Prometheus](https://docs.google.com/document/d/1ebhGNLs3uhdeprJCullM-ywA9iMRDg_mmnuFAQCloqY/edit#heading=h.2rmzk7oo6tu8)
+
+> This proposal collects the requirements and implementation proposals for enhancing Prometheus with native support for info metrics metadata.
+
+## Why
+
+Currently Prometheus "forgets" which are the identifying labels of info metrics upon ingestion, even though this information is present in at least the OpenMetrics protobuf exposition format (the OpenMetrics text exposition format unfortunately lacks this capability).
+The fact that Prometheus lacks a notion of which are info metrics' identifying labels leads to certain problems:
+
+* Explicit knowledge of each info metric's identifying labels must be embedded in join queries for when you wish to enrich queries with data (non-identifying) labels from info metrics.
+* Complex join queries must be written in order to enrich time series with corresponding labels from info metrics.
+  This is particularly problematic in the OpenTelemetry (AKA OTel) context, since users depend on (joining with) the `target_info` info metric in order to add relevant [resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md) back to their Prometheus metrics.
+* If an info metric's data (non-identifying) labels change (a situation that should become more frequent with OTel in the future, as the model will probably start allowing for non-identifying resource attribute mutations), join queries against the info metric (e.g. `target_info`) will temporarily fail due to resolving the join keys to two different metrics, until the old metric is marked stale (by default after five minutes).
+
+Especially in order to provide the best possible OTel experience, the info metric (`target_info` in the case of OTel) staleness problem needs to be solved, so users won't experience temporarily failing join queries while trying to include OTel resource attributes.
+Also, it would be much better if we could provide a simpler query experience where the user doesn't have to know how to write PromQL joins (a fairly complex matter), in order to include e.g. OTel resource attributes.
+Another possible positive outcome might be dedicated support in the Grafana UI for visualizing the resource attributes of each OTel metric.
+
+### Pitfalls of the current solution
+
+Prometheus currently persists info metrics as if they were normal float samples.
+This means that knowledge of info metrics' identifying labels are lost, and you have to base yourself on convention when querying on them (for example that `target_info` should have `job` and `instance` as identifying labels).
+The consequence is that you need relatively expert level PromQL knowledge to include info metric labels in your query results; as OTel grows in popularity, this becomes more and more of a problem as users will want to include certain labels from `target_info` (corresponding to OTel resource attributes).
+Without persisted info metric metadata, one can't build more user friendly abstractions (e.g. a PromQL function) for including OTel resource attributes (or other info metric labels) in query results. Neither can you build dedicated UI for OTel resource attributes (or other info metric labels).
+
+## Goals
+
+Goals and use cases for the solution as proposed in [How](#how):
+
+* Persist info metrics with known identifying labels as a new info metric sample type.
+* Store for each info metric sample (of the new type) which are the identifying labels.
+* Store in the TSDB immediately that the previous version of an info metric is stale, when its data labels change.
+* Add TSDB API for, given a certain time series and a certain timestamp, getting data labels, potentially filtered by certain matchers, from info metrics with identifying labels in common with the time series in question.
+* Simplify inclusion of info metric labels in PromQL.
+
+### Audience
+
+Prometheus maintainers.
+
+## Non-Goals
+
+## How
+
+* A new info metric sample type will be introduced, where the sample value is the info metric's identifying labels.
+* The head and block indexes will be augmented with indexes of info metrics.
+* A method will be added to the TSDB API for matching info metric data labels to a time series, given a certain timestamp and potentially data label matchers - the method will use the aforementioned head and block info metric indexes.
+* Thanks to the head and block info metric indexes, the info metric staleness problem should be solved, since one can pick the latest version of the info metric for overlapping time ranges.
+* We propose simplifying the inclusion of info metric labels in PromQL through a new `info` function (TODO: describe).
+
+* Make it concise and **simple**; put diagrams; be concrete, avoid using “really”, “amazing” and “great” (:
+* How you will test and verify?
+* How you will migrate users, without downtime. How we solve incompatibilities?
+* What open questions are left? (“Known unknowns”)
+
+## Alternatives
+
+The section stating potential alternatives. Highlight the objections reader should have towards your proposal as they read it. Tell them why you still think you should take this path [[ref](https://twitter.com/whereistanya/status/1353853753439490049)]
+
+1. This is why not solution Z...
+
+## Action Plan
+
+The tasks to do in order to migrate to the new idea.
+
+* [ ] Task one <GH issue>
+* [ ] Task two <GH issue> ...

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -120,6 +120,7 @@ sum by (k8s_cluster_name, http_status_code) (
 TODO:
 
 * Specify detection of info metric identifying labels for other ingestion methods than OTLP.
+* Define how this functionality would work together with OOO samples.
 
 ## Alternatives
 

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -124,11 +124,6 @@ sum by (k8s_cluster_name, http_status_code) (
 )
 ```
 
-TODO:
-
-* Specify detection of info metric identifying labels for other ingestion methods than OTLP.
-* Define how this functionality would work together with OOO samples.
-
 ## Alternatives
 
 ### Add metadata as prefixed labels

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -83,6 +83,8 @@ Goals and use cases for the solution as proposed in [How](#how):
     The collision can be resolved by constraining the labels via data label matchers.
     And of course, the user always has the option to go back to the original join syntax (or, even better, avoiding ingesting conflicting info metrics in the first place).
 * Simplify enriching of query results with info metric data (non-identifying) labels in PromQL, e.g. via a new function, based on aforementioned TSDB API.
+* Ensure backwards compatibility with current Prometheus usage.
+* Minimize potential conflicts with existing metric labels.
 
 ### Audience
 

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -146,6 +146,18 @@ Instead of encoding metadata, e.g. OTel resource attributes, as info metric labe
 * Increased series churn when metadata labels change
 * More labels per metric increases CPU/memory usage
 
+### Make the `info` function require specifying the info metric(s)
+
+Instead of letting `info` by default join with all matching info metrics, have it require specifying the info metric name(s).
+
+#### Pros
+
+* The user won't be confused about data labels being included from info metrics they didn't expect
+
+#### Cons
+
+* The UX becomes more complex, as the user is required to specify which info metric(s) to join with
+
 ## Action Plan
 
 The tasks to do in order to migrate to the new idea.

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -1,4 +1,4 @@
-# Add 1st class feature to PromQL for handling info type metrics
+# Simplify joins with info metrics in PromQL
 
 * **Owners:**
   * Arve Knudsen [@aknuds1](https://github.com/aknuds1) [arve.knudsen@grafana.com](mailto:arve.knudsen@grafana.com)
@@ -13,7 +13,7 @@
   * [Special treatment of info metrics in Prometheus](https://docs.google.com/document/d/1ebhGNLs3uhdeprJCullM-ywA9iMRDg_mmnuFAQCloqY/edit#heading=h.2rmzk7oo6tu8)
   * [Scenarios scratch pad](https://docs.google.com/document/d/1nV6N3pDfvZhmG2658huNbFSkz2rsM6SpkHabp9VVpw0/edit#heading=h.luf3yapzr29e)
 
-> This proposal collects the requirements and implementation proposals for adding a 1st class feature to PromQL for handling info type metrics.
+> This proposal collects the requirements and implementation proposals for simplifying joins with info type metrics in PromQL.
 
 ## Why
 

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -17,6 +17,11 @@
 
 ## Why
 
+Info metrics are [defined by the OpenMetrics specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info) as "used to expose textual information which SHOULD NOT change during process lifetime".
+Furthermore the OpenMetrics specification states that info metrics ["MUST have the suffix `_info`"](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info-1).
+Despite the latter OpenMetrics requirement, there are metrics with the info metric usage pattern that don't have the `_info` suffix, e.g. `kube_pod_labels`.
+In this proposal, we shall include the latter in the definition of info metrics.
+
 Currently, enriching Prometheus query results with corresponding labels from info metrics is challenging.
 More specifically, it requires writing advanced PromQL to join with the info metric in question.
 Take as an example querying HTTP request rates per K8s cluster and status code, while having to join with the `target_info` metric to obtain the `k8s_cluster_name` label:

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -50,6 +50,7 @@ There are other problems with Prometheus' current method of including info metri
 If Prometheus could persist info metrics' identifying labels (e.g. `job` and `instance` for `target_info`), human knowledge of the correct identifying labels may become unnecessary when "joining" with info metrics.
 Information about info metric identifying labels is present in at least the OpenMetrics protobuf exposition format (the OpenMetrics text exposition format unfortunately lacks this capability).
 It can also easily be deduced when ingesting metrics from OTLP (OTel Protocol).
+Most info metrics' identifying labels will be `job` and `instance`, but there are some exceptions (e.g. `kube_pod_labels`).
 Intrinsic knowledge of info metrics' identifying labels could also help in solving temporary conflicts between old and new versions of info metrics, when data (non-identifying) labels change.
 Another possible positive outcome might be dedicated support in UIs (e.g. Grafana) for visualizing the resource attributes of OTel metrics.
 

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -1,4 +1,4 @@
-## Native Support for Info Metrics Metadata
+# Add 1st class feature to PromQL for handling info type metrics
 
 * **Owners:**
   * Arve Knudsen [@aknuds1](https://github.com/aknuds1) [arve.knudsen@grafana.com](mailto:arve.knudsen@grafana.com)
@@ -11,39 +11,61 @@
 * **Other docs or links:**
   * [Proper support for OTEL resource attributes](https://docs.google.com/document/d/1FgHxOzCQ1Rom-PjHXsgujK8x5Xx3GTiwyG__U3Gd9Tw/edit#heading=h.unv3m5m27vuc)
   * [Special treatment of info metrics in Prometheus](https://docs.google.com/document/d/1ebhGNLs3uhdeprJCullM-ywA9iMRDg_mmnuFAQCloqY/edit#heading=h.2rmzk7oo6tu8)
+  * [Scenarios scratch pad](https://docs.google.com/document/d/1nV6N3pDfvZhmG2658huNbFSkz2rsM6SpkHabp9VVpw0/edit#heading=h.luf3yapzr29e)
 
-> This proposal collects the requirements and implementation proposals for enhancing Prometheus with native support for info metrics metadata.
+> This proposal collects the requirements and implementation proposals for adding a 1st class feature to PromQL for handling info type metrics.
 
 ## Why
 
-Currently Prometheus "forgets" which are the identifying labels of info metrics upon ingestion, even though this information is present in at least the OpenMetrics protobuf exposition format (the OpenMetrics text exposition format unfortunately lacks this capability).
-The fact that Prometheus lacks a notion of which are info metrics' identifying labels leads to certain problems:
+Currently, enriching Prometheus query results with corresponding labels from info metrics is challenging.
+More specifically, it requires writing advanced PromQL to join with the info metric in question.
+Take as an example querying HTTP request rates per K8s cluster and status code, while having to join with the `target_info` metric to obtain the `k8s_cluster_name` label:
 
+```promql
+sum by (k8s_cluster_name, http_status_code) (
+    rate(http_server_request_duration_seconds_count[2m])
+  * on (job, instance) group_left (k8s_cluster_name)
+    target_info
+)
+```
+
+The `target_info` metric is in fact the motivation for this proposal, as it's how Prometheus encodes OpenTelemetry (OTel for short) [resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md).
+As a result, it's a very important info metric for those using Prometheus as an OTel backend.
+OTel resource attributes model metadata about the environment producing metrics received by the backend (e.g. Prometheus), and Prometheus persists them as labels of `target_info`.
+Typically, OTel users want to include some of these attributes (as `target_info` labels) in their query results, to correlate them with entities of theirs (e.g. K8s pods).
+
+Based on user demand, it would be preferable if Prometheus were to have better UX for enriching query results with info metrics labels, especially with OTel in mind.
+There are other problems with Prometheus' current method of including info metric labels in queries, beyond just the technical barrier:
 * Explicit knowledge of each info metric's identifying labels must be embedded in join queries for when you wish to enrich queries with data (non-identifying) labels from info metrics.
-* Complex join queries must be written in order to enrich time series with corresponding labels from info metrics.
-  This is particularly problematic in the OpenTelemetry (AKA OTel) context, since users depend on (joining with) the `target_info` info metric in order to add relevant [resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md) back to their Prometheus metrics.
+  * A certain pair of OTel resource attributes (`service.name` and `service.instance.id`) are currently assumed to be the identifying pair and mapped to `target_info`'s `job` and `instance` labels respectively, but this may become a dynamic property of the OTel model.
+  * Both attributes are in reality optional, so either of them might be empty (`service.name` is only mandatory for OTel SDK clients).
+  * If both identifying attributes are empty, `target_info` isn't generated (there being no identifying labels to join against).
 * If an info metric's data (non-identifying) labels change (a situation that should become more frequent with OTel in the future, as the model will probably start allowing for non-identifying resource attribute mutations), join queries against the info metric (e.g. `target_info`) will temporarily fail due to resolving the join keys to two different metrics, until the old metric is marked stale (by default after five minutes).
 
-Especially in order to provide the best possible OTel experience, the info metric (`target_info` in the case of OTel) staleness problem needs to be solved, so users won't experience temporarily failing join queries while trying to include OTel resource attributes.
-Also, it would be much better if we could provide a simpler query experience where the user doesn't have to know how to write PromQL joins (a fairly complex matter), in order to include e.g. OTel resource attributes.
-Another possible positive outcome might be dedicated support in the Grafana UI for visualizing the resource attributes of each OTel metric.
+If Prometheus could persist info metrics' identifying labels (e.g. `job` and `instance` for `target_info`), human knowledge of the correct identifying labels may become unnecessary when "joining" with info metrics.
+Information about info metric identifying labels is present in at least the OpenMetrics protobuf exposition format (the OpenMetrics text exposition format unfortunately lacks this capability).
+It can also easily be deduced when ingesting metrics from OTLP (OTel Protocol).
+Intrinsic knowledge of info metrics' identifying labels could also help in solving temporary conflicts between old and new versions of info metrics, when data (non-identifying) labels change.
+Another possible positive outcome might be dedicated support in UIs (e.g. Grafana) for visualizing the resource attributes of OTel metrics.
 
 ### Pitfalls of the current solution
 
 Prometheus currently persists info metrics as if they were normal float samples.
-This means that knowledge of info metrics' identifying labels are lost, and you have to base yourself on convention when querying on them (for example that `target_info` should have `job` and `instance` as identifying labels).
+This means that knowledge of info metrics' identifying labels are lost, and you have to base yourself on convention when querying them (for example that `target_info` should have `job` and `instance` as identifying labels).
+There's also no particular support for enriching query results with info metric labels in PromQL.
 The consequence is that you need relatively expert level PromQL knowledge to include info metric labels in your query results; as OTel grows in popularity, this becomes more and more of a problem as users will want to include certain labels from `target_info` (corresponding to OTel resource attributes).
-Without persisted info metric metadata, one can't build more user friendly abstractions (e.g. a PromQL function) for including OTel resource attributes (or other info metric labels) in query results. Neither can you build dedicated UI for OTel resource attributes (or other info metric labels).
+Without persisted info metric metadata, one can't build more user friendly abstractions (e.g. a PromQL function) for including OTel resource attributes (or other info metric labels) in query results.
+Neither can you build dedicated UI for OTel resource attributes (or other info metric labels).
 
 ## Goals
 
 Goals and use cases for the solution as proposed in [How](#how):
 
-* Persist info metrics with known identifying labels as a new info metric sample type.
-* Store for each info metric sample (of the new type) which are the identifying labels.
-* Store in the TSDB immediately that the previous version of an info metric is stale, when its data labels change.
+* Persist info metrics with labels categorized as either identifying or non-identifying.
+* Track when info metrics' set of identifying labels changes. This shouldn't be a frequent occurrence, but it should be handled.
+* Automatically treat the old version of an info metric as stale for query result enriching purposes, when its data labels change (producing a new time series, but with same identity).
 * Add TSDB API for, given a certain time series and a certain timestamp, getting data labels, potentially filtered by certain matchers, from info metrics with identifying labels in common with the time series in question.
-* Simplify inclusion of info metric labels in PromQL.
+* Simplify enriching of query results with info metric labels in PromQL, e.g. via a new function.
 
 ### Audience
 
@@ -53,12 +75,24 @@ Prometheus maintainers.
 
 ## How
 
-* A new info metric sample type will be introduced, where the sample value is the info metric's identifying labels.
-* The head and block indexes will be augmented with indexes of info metrics.
-* A method will be added to the TSDB API for matching info metric data labels to a time series, given a certain timestamp and potentially data label matchers - the method will use the aforementioned head and block info metric indexes.
-* Thanks to the head and block info metric indexes, the info metric staleness problem should be solved, since one can pick the latest version of the info metric for overlapping time ranges.
-* We propose simplifying the inclusion of info metric labels in PromQL through a new `info` function (TODO: describe).
+* Introduce a new info metric sample type, to track the info metric's identifying label set over time (in case it changes).
+* Augment the head and block indexes with indexes of info metrics, for easy finding of info metrics matching time series.
+* Add a method to the TSDB API for matching info metric data labels to a time series, given a certain timestamp and potentially data label matchers - the method will use the aforementioned head and block info metric indexes.
+* Simplify the inclusion of info metric labels in PromQL through a new `info` function: `info(v instant-vector[, ls label-selector])`.
+  This function will be UI for the aforementioned TSDB API.
 
+Using the `info` function, we can simplify the previously given PromQL join example as follows:
+
+```
+sum by (k8s_cluster_name, http_status_code) (
+  info(
+    rate(http_server_request_duration_seconds_count[2m]),
+    {k8s_cluster_name=~".+"}
+  )
+)
+```
+
+TODO:
 * Make it concise and **simple**; put diagrams; be concrete, avoid using “really”, “amazing” and “great” (:
 * How you will test and verify?
 * How you will migrate users, without downtime. How we solve incompatibilities?

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -88,8 +88,6 @@ Goals and use cases for the solution as proposed in [How](#how):
 
 Prometheus maintainers.
 
-## Non-Goals
-
 ## How
 
 * Introduce a new info metric sample type, to track the info metric's identifying label set over time (in case it changes).

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -130,9 +130,20 @@ TODO:
 
 ## Alternatives
 
-The section stating potential alternatives. Highlight the objections reader should have towards your proposal as they read it. Tell them why you still think you should take this path [[ref](https://twitter.com/whereistanya/status/1353853753439490049)]
+### Add metadata as prefixed labels
 
-1. This is why not solution Z...
+Instead of encoding metadata, e.g. OTel resource attributes, as info metric labels, add them directly as labels to corresponding metrics.
+
+#### Pros
+
+* Simplicity, removes need for joining with info metrics
+
+#### Cons
+
+* Metrics will have potentially far more labels than what's strictly necessary to identify them
+* Temporary series churn when migrating existing metrics to this new scheme
+* Increased series churn when metadata labels change
+* More labels per metric increases CPU/memory usage
 
 ## Action Plan
 

--- a/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
+++ b/proposals/2024-04-10-native-support-for-info-metrics-metadata.md
@@ -98,17 +98,18 @@ Prometheus maintainers.
 
 ## How
 
-* Introduce a new info metric sample type, to track the info metric's identifying label set over time (in case it changes).
-* Augment the head and block indexes with indexes of info metrics, for easy finding of info metrics matching time series.
-  * The TSDB head and every block register their respective info metrics in a corresponding index, with the different identifying label sets each info metric has had over its lifetime.
-* Augment the OTLP endpoint to specify `target_info`'s identifying labels when ingesting write requests, and to store it as the native info metric type.
-* Add a method to the TSDB API for matching info metric data labels to a time series, given a certain timestamp and potentially data label matchers - the method will use the aforementioned head and block info metric indexes.
-  * Candidate info metrics are found by searching the info metric index for info metrics with identifying labels contained in the input label set.
-    * Each candidate info metric's identifying label set _for the timestamp in question_, is obtained from the info metric's samples.
+* Track the info metric's identifying label set over time (in case it changes) - storage model details to be elaborated in separate proposal.
+* Keep info metric indexes in storage - storage model details to be elaborated in separate proposal.
+  * Info metric indexes maintaining per info metric the different identifying label sets it has had over its lifetime.
+  * Indexing the different identifying label sets an info metric has had over its lifetime allows determining which are potential matches for a given metric, before considering the time dimension.
+* Add a method to the TSDB API for matching info metric data labels to a time series, given a certain timestamp and potentially data label matchers - the method will use the aforementioned info metric indexes.
+  * Candidate info metrics are found by searching info metric indexes for info metrics with identifying labels contained in the input label set.
+    * Each candidate info metric's identifying label set is obtained _for the timestamp in question_ - storage model details to be elaborated in separate proposal.
     * If that identifying label set is not a match, the info metric is ignored.
     * If several info metrics with the same name are found, the one with the latest sample is chosen (i.e., older metrics are considered stale).
   * Data labels are picked from the found info metrics according to the rules defined in the Goals section.
     * Each info metric's data labels are determined by taking those of the metric's labels which are not in the identifying label set.
+* Augment the OTLP endpoint to specify `target_info`'s identifying labels when ingesting write requests.
 * Simplify the inclusion of info metric labels in PromQL through a new `info` function: `info(v instant-vector[, ls label-selector])`.
   This function will be UI for the aforementioned TSDB API.
 


### PR DESCRIPTION
I'm adding a proposal about enhancing Prometheus with a 1st class feature to PromQL for easy joining with info type metrics. This is in particular supposed to facilitate OpenTelemetry resource attributes (via the `target_info` metric they get mapped to), but works for info metrics in general.

Please note that in agreement with @codesome, I'm deliberately punting on TSDB details, as @codesome wants to have a separate proposal for those.