### PR TITLE
Native metadata

### DIFF
--- a/proposals/0078-per-series-metadata.md
+++ b/proposals/0078-per-series-metadata.md
@@ -1,0 +1,17 @@
+## Per-series metadata
+
+* **Owners:**
+  * Arve Knudsen [@aknuds1](https://github.com/aknuds1) [aknudsen@prometheus.io](mailto:aknudsen@prometheus.io)
+  * György (krajo) Krajcsovits [@krajorama](https://github.com/krajorama/) [gyorgy.krajcsovits@grafana.com](mailto:gyorgy.krajcsovits@grafana.com)
+
+* **Contributors:**
+
+* **Implementation Status:** `Not implemented`
+
+* **Related Issues and PRs:**
+  * [Store metric metadata in TSDB](https://github.com/prometheus/prometheus/issues/12608)
+
+* **Other docs or links:**
+  * [Proposal document](https://docs.google.com/document/d/1yYnyD7oJDvJhzFaigdniq6y302Mvp9gDcJUeAj3pJ0s/edit?usp=sharing)
+
+For now the proposal is in a Google document at [Proposal document](https://docs.google.com/document/d/1yYnyD7oJDvJhzFaigdniq6y302Mvp9gDcJUeAj3pJ0s/edit?usp=sharing) as it is very much work in progress and we assume it will generate a lot of comments already on the requirements, use cases side.


### PR DESCRIPTION
This design doc is proposing to make some metadata a first class citizen in Prometheus to support new use cases related to OpenTelemetry (OTel), Agentic AI workflows and old ones such as Service Discovery target meta labels storage.