### PR TITLE
ci(proposals): declare contents: read + actions: write

### DIFF
--- a/.github/workflows/proposals.yaml
+++ b/.github/workflows/proposals.yaml
@@ -7,6 +7,11 @@ on:
     tags:
   pull_request:
 
+# actions/cache@v3 saves the Go module cache on miss.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only on contents plus the cache save path. The only workflow uses `actions/cache@v3` for the Go module cache, which saves on miss and therefore needs `actions: write`.