### PR TITLE
proposal: Prometheus internal telemetry as an OTel semantic convention registry

### DIFF
--- a/proposals/0000-semconv-internal-telemetry.md
+++ b/proposals/0000-semconv-internal-telemetry.md
@@ -1,0 +1,206 @@
+# Prometheus Internal Telemetry as an OTel Semantic Convention Registry
+
+* **Owners:**
+  * Nicolas Takashi [@nicolastakashi](https://github.com/nicolastakashi) [nicolas.takashi@coralogix.com](mailto:nicolas.takashi@coralogix.com)
+  * Arthur Silva Sens [@ArthurSens](https://github.com/ArthurSens) [arthursens2005@gmail.com](mailto:arthursens2005@gmail.com)
+
+* **Implementation Status:** `Partially implemented`
+
+* **Related Issues and PRs:**
+  * [WIP: Prometheus semconvs](https://github.com/prometheus/prometheus/pull/17868)
+  * [Weaver: Implement `weaver registry infer` command](https://github.com/open-telemetry/weaver/pull/1138)
+
+* **Other docs or links:**
+  * [Dev Summit notes: internal telemetry consensus](https://docs.google.com/document/d/1uurQCi5iVufhYHGlBZ8mJMK_freDFKPG0iYBQqJ9fvA/edit?tab=t.0#bookmark=id.ojugisgspwvq)
+  * [OpenTelemetry Weaver](https://github.com/open-telemetry/weaver)
+  * [OTel Semantic Convention specification](https://opentelemetry.io/docs/specs/semconv/)
+
+> TL;DR: We propose defining all metrics exported by the Prometheus binary as a formal [OTel semantic convention registry](https://opentelemetry.io/docs/specs/semconv/). A machine-readable schema per package serves as the single source of truth, enabling auto-generated instrumentation code, always-up-to-date metric documentation, contract testing against live instances, and a foundation for safe metric evolution across the Prometheus ecosystem.
+
+## Why
+
+Prometheus defines its own internal metrics as scattered `prometheus/client_golang` constructor calls across dozens of files. There is no machine-readable description of what Prometheus emits.
+
+This creates the following concrete problems:
+
+* Dashboard and alert authors who depend on these metrics have no canonical reference. They reverse-engineer what Prometheus emits by reading Go source or running a live instance.
+* There is no contract distinguishing stable public API metrics from internal implementation details. Metrics can be renamed, removed, or semantically changed without versioned signals.
+* Documentation, if it exists, is written separately from the code and drifts. There is no mechanism to keep it in sync.
+* There is no regression safety. Nothing prevents a code change from silently altering which metrics Prometheus emits or what labels they carry.
+* As Prometheus increasingly interoperates with OTel (OTLP ingestion, remote write, collectors), its own telemetry remains outside the OTel schema world and is invisible to tools that understand semantic conventions.
+
+### Pitfalls of the current solution
+
+* Metric help strings are inconsistent: some describe counter semantics, others describe the event being counted.
+* Histogram bucket configurations are chosen ad hoc with no enforcement.
+* Units are absent from most metric definitions.
+* No lifecycle model exists: no way to mark a metric as experimental, stable, or deprecated in a way that tooling understands.
+* Ecosystem consumers (Thanos, Mimir, Grafana dashboards, alerting rules) have no authoritative reference for what a running Prometheus exposes.
+
+## Goals
+
+* [Required] Define Prometheus' internal telemetry as a formal OTel semantic convention registry (`registry.yaml` per package), making it the single machine-readable source of truth for every metric Prometheus exposes.
+* [Required] Generate instrumentation code from the registry, eliminating hand-written metric definitions in Go.
+* [Required] Generate metric documentation from the registry that cannot drift from the implementation.
+* [Nice to have] Enable contract testing via `weaver registry live-check`: validate that a running Prometheus instance emits exactly what the registry declares.
+* [Required] Establish a metric lifecycle model using OTel stability levels (`development`, `stable`, `deprecated`) as first-class schema information.
+* [Nice to have] Lay the foundation for multi-language instrumentation code generation and ecosystem tooling (dashboards, alerting rules) derived from the same registry.
+
+### Audience
+
+Prometheus maintainers and contributors. Operators and SREs who build dashboards and alerts on top of Prometheus' internal metrics. OTel ecosystem tools that consume or validate Prometheus telemetry.
+
+## Non-Goals
+
+* Changing existing metric names, label names, or semantics. This is a schema-first refactor of how metrics are defined, not what they measure.
+* Adopting the OTel SDK for instrumentation. `prometheus/client_golang` remains the instrumentation layer.
+* Migrating exporters or other ecosystem projects (a natural follow-on, out of scope here).
+* Publishing the registry as part of OTel upstream semantic conventions (possible long term, not required now).
+
+## How
+
+### The registry
+
+Each package that exposes internal metrics has a `registry.yaml` file that fully describes every metric it owns. The exact layout (one file per package vs. a single file for the whole project) is an open question discussed below. The example below uses a per-package layout:
+
+```yaml
+- id: metric.prometheus_tsdb_compaction_duration_seconds
+  type: metric
+  stability: stable
+  brief: Duration of compaction runs.
+  metric_name: prometheus_tsdb_compaction_duration_seconds
+  instrument: histogram
+  unit: s
+  annotations:
+    prometheus:
+      histogram_type: mixed_histogram
+      exponential_buckets: {start: 1, factor: 2, count: 14}
+      bucket_factor: 1.1
+      max_bucket_number: 100
+      min_reset_duration: "1h"
+```
+
+This file is the contract. Go code, documentation, and contract tests are all derived from it. The `annotations.prometheus` block carries Prometheus-specific details invisible to OTel (histogram variant, bucket configuration, callback-based gauges, labels fixed at construction time).
+
+The repository structure is:
+
+```
+pkg/semconv/
+  registry.yaml   ← source of truth, hand-authored
+  metrics.go      ← generated, DO NOT EDIT
+  README.md       ← generated, DO NOT EDIT
+```
+
+The Weaver templates and Rego policies used during generation are not committed to this repository. Where they live is an open question discussed below; the generation step resolves them at build time.
+
+### Instrumentation code generation
+
+[OTel Weaver](https://github.com/open-telemetry/weaver) renders `registry.yaml` files into typed Go code via Jinja2 templates. A Makefile target regenerates all `semconv/metrics.go` files across the repository. CI enforces that generated files stay in sync with their registries.
+
+A metric without labels generates a plain embedded type:
+
+```go
+type PrometheusTSDBCompactionDurationSeconds struct { prometheus.Histogram }
+
+func NewPrometheusTSDBCompactionDurationSeconds() PrometheusTSDBCompactionDurationSeconds { ... }
+```
+
+A metric with dynamic labels generates a typed `.With()` method that accepts a sealed per-metric interface, catching incorrect label usage at compile time:
+
+```go
+func (m PrometheusTargetScrapeDurationSeconds) With(
+    interval IntervalAttr,
+    extra ...PrometheusTargetScrapeDurationSecondsAttr,
+) prometheus.Observer { ... }
+```
+
+A metric with labels fixed at construction time (`const_labels`) accepts those as typed constructor parameters:
+
+```go
+func NewPrometheusSDDiscoveredTargets(name NameAttr) PrometheusSDDiscoveredTargets { ... }
+```
+
+A callback-based gauge (`GaugeFunc`) uses `only_opts: true` in the registry, which generates only an `Opts()` function:
+
+```go
+func PrometheusTSDBHeadSeriesOpts() prometheus.GaugeOpts { ... }
+// Caller wires in the callback:
+prometheus.NewGaugeFunc(semconv.PrometheusTSDBHeadSeriesOpts(), func() float64 { ... })
+```
+
+Package code then imports the generated types directly:
+
+```go
+import semconv "github.com/prometheus/prometheus/tsdb/semconv"
+
+duration: semconv.NewPrometheusTSDBCompactionDurationSeconds(),
+```
+
+### Documentation generation
+
+The same Weaver invocation that produces `metrics.go` also produces a `README.md` per package: a complete structured reference of every metric, including name, type, unit, label semantics, stability level, and examples. Because both files are rendered from the same `registry.yaml`, documentation cannot drift from the code.
+
+### Contract testing
+
+`weaver registry live-check` validates live OTLP telemetry against a registry. By routing a running Prometheus' metrics through an OTel collector (Prometheus receiver → OTLP exporter) and into `live-check`, we can assert that what Prometheus emits matches the declared schema in terms of metric names, label names, types, and units.
+
+The exact approach to contract testing is an open question discussed below.
+
+### Metric lifecycle and evolution
+
+OTel stability levels are first-class fields in `registry.yaml`:
+
+* `development`: internal or experimental, may change without notice.
+* `stable`: public API, changes require a deprecation cycle.
+* `deprecated`: kept for backward compatibility, will be removed in a future major version.
+
+Weaver's code generator can use these levels to emit deprecation warnings in generated code and to omit deprecated metrics from new generation targets. This gives Prometheus a formalized metric evolution model: a stable metric cannot be removed without a schema change that goes through proposal review, and the schema change is auditable in git history.
+
+### Rego validation policies
+
+A set of [OPA Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policies validates each `registry.yaml` before code generation. Where those policies are hosted is part of the open question on template hosting below.
+
+* Every `histogram` instrument must declare `annotations.prometheus.histogram_type`.
+* Valid values for `histogram_type` are `classic_histogram`, `native_histogram`, `mixed_histogram`, `summary`.
+* Classic and mixed histograms must declare `buckets` or `exponential_buckets`.
+* Native and mixed histograms must declare `bucket_factor`, `max_bucket_number`, `min_reset_duration`.
+
+Validation runs as part of the generation step and fails the build if any registry violates the policies.
+
+### Open questions
+
+* **`.With()` allocations on hot paths**: The generated `.With()` method allocates a `prometheus.Labels` map on each call. For high-frequency paths such as per-scrape counters or per-sample append metrics, this may be too expensive. A typed `WithX(value string)` fast path should be benchmarked before broad rollout. See the related [reviewer comment](https://github.com/prometheus/prometheus/pull/17868#discussion_r2716984753).
+
+* **Contract testing coverage**: Many Prometheus metrics are only emitted when specific server state is reached. Compaction metrics require a compaction to be triggered; out-of-order sample counters require out-of-order writes; per-alertmanager metrics require an alertmanager to be configured. A `live-check` run against a basic Prometheus instance will therefore not cover the full registry. Two approaches are possible: (1) build a comprehensive integration test harness that exercises all code paths before running `live-check`; (2) ensure Prometheus initializes all metric vectors at startup even if their values are zero, so the schema can be validated structurally without requiring the underlying events. The right approach needs to be decided.
+
+* **Registry layout**: The registry could live as one `registry.yaml` per package (co-located with the package it describes, ownership is clear, changes are scoped) or as a single `registry.yaml` at the repository root (one place to look, simpler Weaver invocation, but creates a merge bottleneck and couples all metrics to a single file). The per-package layout matches how Go code is already structured and was used in the proof-of-concept, but a single-file layout may be preferable for cross-cutting concerns like stability level audits or global name uniqueness checks.
+
+* **Template and policy hosting**: The Jinja2 templates and Rego policies that drive code generation need to live somewhere accessible at build time. Three options are under consideration: (1) in this repository under a `build/` directory, keeping everything self-contained but coupling the templates to the Prometheus server; (2) in `prometheus/client_golang`, making them reusable across the ecosystem; (3) bundled into the Weaver binary itself, which Weaver is actively developing ([weaver#1145](https://github.com/open-telemetry/weaver/pull/1145)) and would remove the hosting question entirely. This decision needs to be made before the migration can be considered stable.
+
+* **Generated file naming**: Generated files should use a `.gen.go` suffix (e.g. `metrics.gen.go`) to make their nature unambiguous to tooling and contributors.
+
+* **Package visibility**: Generated packages are currently exported. Making them `internal` would prevent accidental external imports but would complicate any cross-package metric sharing.
+
+## Alternatives
+
+### Hand-written schema with a custom linter
+
+A custom linter enforces naming conventions, unit presence, and histogram type rules on existing `prometheus.NewCounter(...)` definitions, without introducing Weaver or YAML.
+
+This solution is not chosen because a linter validates code but cannot generate documentation, drive contract tests, or express metric lifecycle. It solves only the consistency problem while leaving the schema-as-contract and ecosystem tooling problems completely unaddressed. It is also more engineering effort to build and maintain than adopting an existing tool.
+
+### Adopt OTel SDK for instrumentation
+
+Replace `prometheus/client_golang` with the OTel Go SDK and emit metrics via OTLP natively, using OTel's toolchain end-to-end.
+
+This solution is not chosen because Prometheus is the reference implementation of the Prometheus data model. Using a different SDK for its own instrumentation would be surprising to contributors and would add a heavyweight dependency. This proposal deliberately keeps `client_golang` as the instrumentation layer and uses Weaver only at the schema and generation layer. The two concerns are separable.
+
+### Publish registry as upstream OTel semantic conventions
+
+Contribute `prometheus_*` metric definitions directly to `open-telemetry/semantic-conventions`.
+
+This solution is not chosen because Prometheus' internal metrics describe Prometheus' own implementation, not a general convention for other software to follow. If the schema matures and becomes relevant for compatible implementations (e.g. Thanos, Mimir), contributing upstream is a natural follow-on. It is not a prerequisite.
+
+## Action Plan
+
+To be defined based on community feedback and resolution of the open questions above.

--- a/proposals/0086-semconv-internal-telemetry.md
+++ b/proposals/0086-semconv-internal-telemetry.md
@@ -64,20 +64,21 @@ Prometheus maintainers and contributors. Operators and SREs who build dashboards
 Each package that exposes internal metrics has a `registry.yaml` file that fully describes every metric it owns. The exact layout (one file per package vs. a single file for the whole project) is an open question discussed below. The example below uses a per-package layout:
 
 ```yaml
-- id: metric.prometheus_tsdb_compaction_duration_seconds
-  type: metric
-  stability: stable
-  brief: Duration of compaction runs.
-  metric_name: prometheus_tsdb_compaction_duration_seconds
-  instrument: histogram
-  unit: s
-  annotations:
-    prometheus:
-      histogram_type: mixed_histogram
-      exponential_buckets: {start: 1, factor: 2, count: 14}
-      bucket_factor: 1.1
-      max_bucket_number: 100
-      min_reset_duration: "1h"
+groups:
+  - id: metric.prometheus_tsdb_compaction_duration_seconds
+    type: metric
+    stability: stable
+    brief: Duration of compaction runs.
+    metric_name: prometheus_tsdb_compaction_duration_seconds
+    instrument: histogram
+    unit: s
+    annotations:
+      prometheus:
+        histogram_type: mixed_histogram
+        exponential_buckets: {start: 1, factor: 2, count: 14}
+        bucket_factor: 1.1
+        max_bucket_number: 100
+        min_reset_duration: "1h"
 ```
 
 This file is the contract. Go code, documentation, and contract tests are all derived from it. The `annotations.prometheus` block carries Prometheus-specific details invisible to OTel (histogram variant, bucket configuration, callback-based gauges, labels fixed at construction time).
@@ -86,16 +87,16 @@ The repository structure is:
 
 ```
 pkg/semconv/
-  registry.yaml   ← source of truth, hand-authored
-  metrics.go      ← generated, DO NOT EDIT
-  README.md       ← generated, DO NOT EDIT
+  registry.yaml    ← source of truth, hand-authored
+  metrics.gen.go   ← generated, DO NOT EDIT
+  README.md        ← generated, DO NOT EDIT
 ```
 
 The Weaver templates and Rego policies used during generation are not committed to this repository. Where they live is an open question discussed below; the generation step resolves them at build time.
 
 ### Instrumentation code generation
 
-[OTel Weaver](https://github.com/open-telemetry/weaver) renders `registry.yaml` files into typed Go code via Jinja2 templates. A Makefile target regenerates all `semconv/metrics.go` files across the repository. CI enforces that generated files stay in sync with their registries.
+[OTel Weaver](https://github.com/open-telemetry/weaver) renders `registry.yaml` files into typed Go code via Jinja2 templates. A Makefile target regenerates all `semconv/metrics.gen.go` files across the repository. CI enforces that generated files stay in sync with their registries.
 
 A metric without labels generates a plain embedded type:
 
@@ -108,9 +109,9 @@ func NewPrometheusTSDBCompactionDurationSeconds() PrometheusTSDBCompactionDurati
 A metric with dynamic labels generates a typed `.With()` method that accepts a sealed per-metric interface, catching incorrect label usage at compile time:
 
 ```go
-func (m PrometheusTargetScrapeDurationSeconds) With(
+func (m PrometheusTargetIntervalLengthSeconds) With(
     interval IntervalAttr,
-    extra ...PrometheusTargetScrapeDurationSecondsAttr,
+    extra ...PrometheusTargetIntervalLengthSecondsAttr,
 ) prometheus.Observer { ... }
 ```
 
@@ -120,13 +121,50 @@ A metric with labels fixed at construction time (`const_labels`) accepts those a
 func NewPrometheusSDDiscoveredTargets(name NameAttr) PrometheusSDDiscoveredTargets { ... }
 ```
 
-A callback-based gauge (`GaugeFunc`) uses `only_opts: true` in the registry, which generates only an `Opts()` function:
+A callback-based gauge (`prometheus.GaugeFunc`) is the one case where generated code cannot own the whole metric. Its value comes from a closure that reads live server state at scrape time, and that closure can only be written by hand in the package — it references runtime objects the generator knows nothing about. For these metrics the registry sets `only_opts: true`:
+
+```yaml
+  - id: metric.prometheus_tsdb_head_series
+    type: metric
+    stability: development
+    brief: Total number of series in the head block.
+    metric_name: prometheus_tsdb_head_series
+    instrument: gauge
+    unit: "{series}"
+    annotations:
+      prometheus:
+        only_opts: true  # implemented as a GaugeFunc
+```
+
+Weaver then generates only an `Opts()` accessor carrying the schema-owned name, help, and unit — not a full constructor:
 
 ```go
-func PrometheusTSDBHeadSeriesOpts() prometheus.GaugeOpts { ... }
-// Caller wires in the callback:
-prometheus.NewGaugeFunc(semconv.PrometheusTSDBHeadSeriesOpts(), func() float64 { ... })
+func PrometheusTSDBHeadSeriesOpts() prometheus.GaugeOpts {
+    return prometheus.GaugeOpts{
+        Name: "prometheus_tsdb_head_series",
+        Help: "Total number of series in the head block.",
+    }
+}
 ```
+
+The package keeps ownership of the callback and wires it into `NewGaugeFunc`, passing the generated opts in place of the hand-written ones:
+
+```go
+// Before: name and help are written inline, free to drift from any schema.
+m.series = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+    Name: "prometheus_tsdb_head_series",
+    Help: "Total number of series in the head block.",
+}, func() float64 {
+    return float64(h.NumSeries())
+})
+
+// After: name, help, and unit come from the registry; only the callback stays in code.
+m.series = prometheus.NewGaugeFunc(semconv.PrometheusTSDBHeadSeriesOpts(), func() float64 {
+    return float64(h.NumSeries())
+})
+```
+
+The metric's identity (name, help, unit, stability) is now under schema control, while the runtime value source — the part that genuinely depends on live state — stays in hand-written code.
 
 Package code then imports the generated types directly:
 
@@ -138,7 +176,7 @@ duration: semconv.NewPrometheusTSDBCompactionDurationSeconds(),
 
 ### Documentation generation
 
-The same Weaver invocation that produces `metrics.go` also produces a `README.md` per package: a complete structured reference of every metric, including name, type, unit, label semantics, stability level, and examples. Because both files are rendered from the same `registry.yaml`, documentation cannot drift from the code.
+The same Weaver invocation that produces `metrics.gen.go` also produces a `README.md` per package: a complete structured reference of every metric, including name, type, unit, label semantics, stability level, and examples. Because both files are rendered from the same `registry.yaml`, documentation cannot drift from the code.
 
 ### Contract testing
 
@@ -177,7 +215,7 @@ Validation runs as part of the generation step and fails the build if any regist
 
 * **Template and policy hosting**: The Jinja2 templates and Rego policies that drive code generation need to live somewhere accessible at build time. Three options are under consideration: (1) in this repository under a `build/` directory, keeping everything self-contained but coupling the templates to the Prometheus server; (2) in `prometheus/client_golang`, making them reusable across the ecosystem; (3) bundled into the Weaver binary itself, which Weaver is actively developing ([weaver#1145](https://github.com/open-telemetry/weaver/pull/1145)) and would remove the hosting question entirely. This decision needs to be made before the migration can be considered stable.
 
-* **Generated file naming**: Generated files should use a `.gen.go` suffix (e.g. `metrics.gen.go`) to make their nature unambiguous to tooling and contributors.
+* **Generated file naming**: This proposal adopts a `.gen.go` suffix (e.g. `metrics.gen.go`) to make the generated nature of these files unambiguous to tooling and contributors. This is open only to the extent that the community may prefer a different convention.
 
 * **Package visibility**: Generated packages are currently exported. Making them `internal` would prevent accidental external imports but would complicate any cross-package metric sharing.
 

--- a/proposals/0086-semconv-internal-telemetry.md
+++ b/proposals/0086-semconv-internal-telemetry.md
@@ -121,7 +121,7 @@ A metric with labels fixed at construction time (`const_labels`) accepts those a
 func NewPrometheusSDDiscoveredTargets(name NameAttr) PrometheusSDDiscoveredTargets { ... }
 ```
 
-A callback-based gauge (`prometheus.GaugeFunc`) is the one case where generated code cannot own the whole metric. Its value comes from a closure that reads live server state at scrape time, and that closure can only be written by hand in the package — it references runtime objects the generator knows nothing about. For these metrics the registry sets `only_opts: true`:
+A callback-based gauge (`prometheus.GaugeFunc`) is special: its value is pulled from a closure at scrape time rather than `Set()` by the program, so the no-argument constructor that the other instruments get does not fit. For these metrics the registry sets `only_opts: true`:
 
 ```yaml
   - id: metric.prometheus_tsdb_head_series

--- a/proposals/0086-semconv-internal-telemetry.md
+++ b/proposals/0086-semconv-internal-telemetry.md
@@ -1,0 +1,178 @@
+# Prometheus Internal Telemetry as an OTel Semantic Convention Registry
+
+* **Owners:**
+  * Nicolas Takashi [@nicolastakashi](https://github.com/nicolastakashi) [nicolas.takashi@coralogix.com](mailto:nicolas.takashi@coralogix.com)
+  * Arthur Silva Sens [@ArthurSens](https://github.com/ArthurSens) [arthursens2005@gmail.com](mailto:arthursens2005@gmail.com)
+
+* **Implementation Status:** `Partially implemented`
+
+* **Related Issues and PRs:**
+  * [WIP: Prometheus semconvs](https://github.com/prometheus/prometheus/pull/17868)
+
+* **Other docs or links:**
+  * [Dev Summit notes: internal telemetry consensus](https://docs.google.com/document/d/1uurQCi5iVufhYHGlBZ8mJMK_freDFKPG0iYBQqJ9fvA/edit?tab=t.0#bookmark=id.ojugisgspwvq)
+  * [OTel Semantic Convention specification](https://opentelemetry.io/docs/specs/semconv/): YAML schemas describing telemetry, with tooling to generate code and docs from them.
+  * [OpenTelemetry Weaver](https://github.com/open-telemetry/weaver): the toolchain that resolves, validates, and renders those schemas.
+
+> TL;DR: Define every metric the Prometheus binary exports in one [OTel semantic convention registry](https://opentelemetry.io/docs/specs/semconv/). Generate the instrumentation code and the docs from it, check the code against it in CI, and publish it so downstream projects can check their own references.
+
+## Why
+
+Prometheus' internal metrics are `client_golang` constructor calls scattered across dozens of files. Nothing describes them in machine-readable form, which costs us four ways:
+
+* Dashboard and alert authors reverse-engineer it from Go source or a live instance.
+* Nothing separates stable metrics from implementation details, so renames and semantic changes ship unannounced.
+* Documentation is hand-written, with nothing keeping it honest.
+* No test notices when a code change alters which metrics exist or what labels they carry.
+
+### Pitfalls of the current solution
+
+Help strings are inconsistent, some describing counter semantics and some the event counted. Histogram buckets are picked ad hoc and most metrics carry no unit. Nothing marks a metric experimental, stable, or deprecated in a way tooling can act on. Thanos, Mimir, and every dashboard built on our internals can only check against a live instance, and only for whatever that instance happened to emit.
+
+## Goals
+
+* [Required] One machine-readable registry describes every metric Prometheus exposes. The Go code stops being a second source of truth.
+* [Required] No hand-written metric descriptors. Instrumentation code comes from the registry.
+* [Required] Generated documentation, which therefore cannot drift.
+* [Required] A CI check that catches drift between the registry and the binary, with no OTel Collector and no Weaver binary in the test path.
+* [Required] Stability (`development`, `stable`, `deprecated`) as a schema field, so lifecycle changes are reviewable.
+* [Nice to have] A base for multi-language generation and ecosystem tooling built on the same registry.
+
+### Audience
+
+Prometheus maintainers and contributors. Operators who build dashboards and alerts on these metrics. OTel tools that consume our telemetry.
+
+## Non-Goals
+
+* Changing metric names, labels, or semantics. It changes how metrics are defined, not what they measure.
+* Adopting the OTel SDK. `client_golang` stays the instrumentation layer.
+* Migrating exporters or other ecosystem projects.
+* Publishing the registry as upstream OTel semantic conventions.
+
+## How
+
+### The registry
+
+One `semconv/registry.yaml` describes every metric the binary exposes. A single file keeps name uniqueness and stability audits trivial and gives consumers one artifact to fetch. Split it per package later if it gets unwieldy.
+
+```yaml
+groups:
+  - id: metric.prometheus_tsdb_compaction_duration_seconds
+    type: metric
+    stability: stable
+    brief: Duration of compaction runs.
+    metric_name: prometheus_tsdb_compaction_duration_seconds
+    instrument: histogram
+    unit: s
+    annotations:
+      prometheus:
+        histogram_type: mixed_histogram
+        exponential_buckets: {start: 1, factor: 2, count: 14}
+        bucket_factor: 1.1
+        max_bucket_number: 100
+        min_reset_duration: "1h"
+```
+
+Go code, documentation, and the contract test all derive from this file. `annotations.prometheus` carries what OTel has no field for: histogram variant, buckets, callback gauges, and construction-time labels.
+
+Generated output lands in `<package>/internal/semconv/` as `metrics.gen.go` and `README.md`. `internal` keeps generated types out of the public API and `.gen.go` marks their origin, both per review feedback on the [proof-of-concept](https://github.com/prometheus/prometheus/pull/17868). Templates and policies are not committed here; see the hosting question.
+
+### Instrumentation code generation
+
+Weaver renders the registry into typed Go through Jinja2 templates. A Makefile target regenerates everything and CI fails on drift.
+
+Labelled metrics get a typed `.With()` taking a sealed per-metric interface, so a wrong label is a compile error:
+
+```go
+func (m PrometheusTargetIntervalLengthSeconds) With(
+    interval IntervalAttr,
+    extra ...PrometheusTargetIntervalLengthSecondsAttr,
+) prometheus.Observer { ... }
+```
+
+Unlabelled metrics get a plain constructor and `const_labels` become constructor parameters. `GaugeFunc` is the exception: its value comes from a closure at scrape time, so the registry marks it `only_opts: true`, Weaver emits only an `Opts()` accessor, and the closure stays hand-written.
+
+Package code imports these types from `<package>/internal/semconv`. The generated API shape is not settled; we fix it while migrating the first package.
+
+The same Weaver run also emits a `README.md` per package covering name, type, unit, label semantics, stability, and examples for every metric. Same input as the code, so the two cannot disagree.
+
+### Contract testing
+
+A Go test compares what the code declares against the registry. No running Prometheus, nothing installed.
+
+`Collector.Describe()` yields a descriptor for every metric a collector declares, sample or no sample. The test registers the collectors, reads the descriptors, and compares them to the registry. This needs accessors on `prometheus.Desc`, which today exposes only `Err()` and `String()`. Additive, no new dependencies.
+
+Declarations beat scrapes, because a running instance emits much less than it declares. Configure no Alertmanager and the notifier's per-alertmanager metrics never appear. `Describe()` returns them anyway, with the unit and the const-versus-variable label split that a scrape drops.
+
+It also catches a metric nobody registered. Delete one collector from a `MustRegister` call and it compiles, `go vet` stays quiet, regeneration produces no diff, and the metric never exists at runtime. Generation cannot help, because the wiring is hand-written.
+
+The test reads a flat, already-resolved registry, leaving `ref`, `extends`, imports, and group merging to Weaver at authoring time. It catches drift before it ships, but tells a deployed downstream nothing about how to follow a rename. That needs a versioned rename schema per release, a follow-on.
+
+### Metric lifecycle and evolution
+
+`registry.yaml` carries OTel stability levels: `development` for anything that may change without notice, `stable` for public API needing a deprecation cycle, `deprecated` for metrics kept until a major version drops them. Weaver can emit deprecation warnings from these, and removing a stable metric requires a schema change visible in review and in git history.
+
+This proposal adds the field and makes changes to it reviewable. It does not define what `stable` obligates, how long a deprecation cycle runs, or which of today's metrics qualify. That is policy, not schema, and marking a metric `stable` commits us to compatibility we have never promised. Migrated metrics carry `development` until a follow-on decides otherwise.
+
+### What "across the ecosystem" means
+
+Downstream projects hardcode our internal metric names and learn about a change when a user reports a dead panel. [`samber/awesome-prometheus-alerts`](https://github.com/samber/awesome-prometheus-alerts) hardcodes 37 distinct `prometheus_*` names across roughly 1,150 rule entries, spanning the same packages this proposal migrates. [`perses/community-mixins`](https://github.com/perses/community-mixins) writes metric names into Go queries. Neither can validate those references against anything.
+
+A published registry gives them something to read. A mixin can compare its references against the declared metrics and fail its own CI when one stops resolving, changes type or unit, or loses a label it groups by. That runs on the consumer's schedule and needs nothing from us beyond a fetchable registry. Exporters adopting the format get the same, though migrating them is out of scope.
+
+So "safe metric evolution across the ecosystem" means consumers detect drift themselves, and nothing more.
+
+### Rego validation policies
+
+[OPA Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policies validate the registry during generation and fail the build on a violation:
+
+* Every `histogram` declares `annotations.prometheus.histogram_type`, one of `classic_histogram`, `native_histogram`, `mixed_histogram`, `summary`.
+* Classic and mixed histograms declare `buckets` or `exponential_buckets`.
+* Native and mixed histograms declare `bucket_factor`, `max_bucket_number`, and `min_reset_duration`.
+
+### Open questions
+
+* **`.With()` allocations on hot paths**: `.With()` allocates a `prometheus.Labels` map per call, likely too much for per-scrape or per-sample metrics. Benchmark a typed `WithX(value string)` fast path first ([reviewer comment](https://github.com/prometheus/prometheus/pull/17868#discussion_r2716984753)).
+
+* **Validator module home**: the `Desc` accessors are the only `client_golang` change proposed here. Registry parsing stays out, because `client_golang` is one module with no nested `go.mod`, so a schema package there would push YAML and OTel-schema dependencies onto nearly every exporter. It could live in a nested module there, a new repository under `prometheus`, or elsewhere. Blocks nothing else.
+
+* **Mapping registry entries to packages**: generation needs to know which package owns each metric. A group annotation is the obvious mechanism; the shape is an implementation detail.
+
+* **Template and policy hosting**: in this repository under `build/`, in `client_golang` for ecosystem reuse, or bundled into Weaver itself ([weaver#1145](https://github.com/open-telemetry/weaver/pull/1145)), which would end the question. Decide before the migration is stable.
+
+## Alternatives
+
+### Use Weaver `live-check` for contract testing
+
+Weaver ships `registry live-check`. Route a running Prometheus through a Collector (Prometheus receiver → OTLP exporter) into it and contract testing needs no new code.
+
+Three problems. It checks post-translation telemetry, so the registry describes the OTLP form rather than what Prometheus emits, and a translation bug fails the check as if the registry were wrong. It puts a Collector in the test harness, for us and for every consumer. It needs the Weaver binary at test time, turning a Rust toolchain maintainers install once to generate into one every contributor installs to run tests. A Go test reading `Describe()` needs none of that.
+
+### Hand-written definitions with linting only
+
+Keep the constructor calls and enforce naming, units, and histogram rules with `promlint`, which wires into any registry through `testutil.GatherAndLint`. A linter has no notion of which metrics are *supposed* to exist, so it misses a removal, a rename, or a new label, which are the changes that break consumers. It also cannot generate documentation or hold a lifecycle.
+
+### Generate the registry from instrumentation code
+
+Invert the direction: emit `registry.yaml` from the binary using the same `Desc` introspection and commit it as a golden file, the way Go tracks its own API in `api/go1.*.txt`. CI fails on a diff.
+
+This costs contributors almost nothing and gives regression safety on its own. It is not chosen because the registry stops being authoritative: help text, units, and stability go back to living inline in Go with nothing enforcing them, and there is no schema to generate docs from or hang a lifecycle on. It stays available as a fallback.
+
+### Adopt OTel SDK for instrumentation
+
+Prometheus is the reference implementation of its own data model. Instrumenting it with a different SDK would surprise contributors and add a heavy dependency. Weaver stays at the schema layer, `client_golang` at the instrumentation layer.
+
+### Publish registry as upstream OTel semantic conventions
+
+These metrics describe Prometheus' own implementation, not a convention for others to follow. If the schema matures and fits Thanos or Mimir, contributing upstream is a follow-on rather than a prerequisite.
+
+## Action Plan
+
+* [ ] Get consensus on this proposal.
+* [ ] Add `Desc` accessors to `client_golang` so declared metrics can be read.
+* [ ] Write `semconv/registry.yaml` by hand, package by package.
+* [ ] Build in-process contract testing, one package at a time, and run it in CI.
+* [ ] Generate code for one small package and settle the generated API there.
+* [ ] Benchmark `.With()` before touching hot paths.
+* [ ] Generate the rest, one pull request per package.
+* [ ] Add the Makefile target and CI check that generated files match the registry.


### PR DESCRIPTION
This proposal defines all metrics exported by the Prometheus binary as a formal OTel semantic convention registry. Making the schema machine-readable enables auto-generated instrumentation code, always-in-sync documentation, contract testing against live instances, and a lifecycle model for safe metric evolution across the Prometheus ecosystem.

Proof-of-concept implementation: https://github.com/prometheus/prometheus/pull/17868